### PR TITLE
Major performance improvements (#10)

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -7,6 +7,7 @@ constexpr int kWindowWidth = 640;
 constexpr int kWindowHeight = 480;
 constexpr int kFps = 50;
 constexpr int kMaxFrameTimeMs = 1000 / kFps;
+constexpr int kFramesPerFpsCheck = 100;
 }  // namespace constants
 
 #endif /* CONSTANTS_H */

--- a/game.cpp
+++ b/game.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 
 #include "constants.h"
+#include "perf.h"
 
 Game::Game() {}
 
@@ -25,8 +26,14 @@ bool Game::Run() {
   // DELETE THIS EVENTUALLY
   int goku_location = 0;
 
+  // Create a perf object.
+  Perf perf(true, constants::kFramesPerFpsCheck);
+
   // The game loop.
   while (true) {
+    perf.StartTimer("game_loop");
+    perf.StartTimer("input");
+
     // Clear out old keyup/keydown events.
     input_.BeginNewFrame();
 
@@ -60,16 +67,27 @@ bool Game::Run() {
         input_.IsKeyHeld(SDL_SCANCODE_D)) {
       goku_location += 4;
     }
+    perf.StopTimer("input");
 
-    Sprite sprite("dbz_character_sprites", {.x = 0, .y = 86, .w = 32, .h = 40});
+    perf.StartTimer("create_sprite");
+    Sprite sprite("dbz_character_sprites", {.x = 0, .y = 86, .w = 32, .h = 40},
+                  graphics_.GetRenderer());
     SDL_Rect destination = {.x = goku_location % (constants::kWindowWidth - 64),
                             .y = 30,
                             .w = 64,
                             .h = 80};
-    graphics_.AddSprite(sprite, destination);
+    perf.StopTimer("create_sprite");
 
-    // TODO: Update the frame here.
+    perf.StartTimer("add_sprite");
+    graphics_.AddSprite(sprite, destination, &perf);
+    perf.StopTimer("add_sprite");
+
+    perf.StartTimer("draw");
     graphics_.DrawNextFrame();
+    perf.StopTimer("draw");
+
+    perf.StopTimer("game_loop");
+    perf.ReportResults();
   }
 }
 

--- a/graphics.cpp
+++ b/graphics.cpp
@@ -6,8 +6,6 @@
 
 // Graphics-related constants.
 constexpr char kGameTitle[] = "DBZ";
-// Check the FPS this often.
-constexpr int kFramesPerFpsCheck = 100;
 constexpr float kMsPerSecond = 1000.0;
 
 Graphics::Graphics() : number_of_frames_drawn_(0), last_fps_check_time_ms_(0) {}
@@ -64,23 +62,22 @@ void Graphics::DrawNextFrame() {
 }
 
 void Graphics::CalculateFps() {
-  if (number_of_frames_drawn_ % kFramesPerFpsCheck == 0 &&
+  if (number_of_frames_drawn_ % constants::kFramesPerFpsCheck == 0 &&
       number_of_frames_drawn_ > 0) {
     int current_time = SDL_GetTicks();
     int elapsed_time = current_time - last_fps_check_time_ms_;
-    float fps =
-        static_cast<float>(kFramesPerFpsCheck) / (elapsed_time / kMsPerSecond);
+    float fps = static_cast<float>(constants::kFramesPerFpsCheck) /
+                (elapsed_time / kMsPerSecond);
     std::cout << "FPS: " << fps << std::endl;
     last_fps_check_time_ms_ = SDL_GetTicks();
   }
   number_of_frames_drawn_++;
 }
-void Graphics::AddSprite(const Sprite& sprite, const SDL_Rect& destination) {
-  // Get a texture from the surface.
-  SDL_Texture* texture =
-      SDL_CreateTextureFromSurface(renderer_, sprite.GetSpriteSheet());
-
+void Graphics::AddSprite(const Sprite& sprite, const SDL_Rect& destination,
+                         Perf* perf) {
   // Draw this sprite on the screen.
   SDL_Rect source = sprite.GetSourceLocation();
-  SDL_RenderCopy(renderer_, texture, &source, &destination);
+  perf->StartTimer("render_copy");
+  SDL_RenderCopy(renderer_, sprite.GetSpriteTexture(), &source, &destination);
+  perf->StopTimer("render_copy");
 }

--- a/graphics.h
+++ b/graphics.h
@@ -2,6 +2,7 @@
 #define GRAPHICS_H
 #include <SDL2/SDL.h>
 
+#include "perf.h"
 #include "sprite.h"
 
 // Structure to hold the RGB values of the background color.
@@ -27,7 +28,17 @@ class Graphics {
 
   // Add this sprite to the renderer for the next frame at the specified
   // location.
-  void AddSprite(const Sprite& sprite, const SDL_Rect& destination);
+  void AddSprite(const Sprite& sprite, const SDL_Rect& destination,
+                 Perf* perf);
+
+  // This returns a pointer to the renderer struct.
+  // Exposing this is unfortunate but the Sprite needs access to it to create
+  // textures.
+  // This method should be used with caution.
+  // The graphics class still owns the renderer.
+  SDL_Renderer* GetRenderer() {
+    return renderer_;
+  }
 
  private:
   // Compute the FPS every 100 frames and write it to the screen.

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Some useful variables
-OBJS = graphics.o input.o main.o sprite.o game.o
-CFLAGS = -Wall -g -O3
+OBJS = graphics.o input.o main.o sprite.o game.o perf.o
+CFLAGS = -Wall -g -std=c++17
 LIBS = `sdl2-config --cflags --libs` -lSDL2_image
 CC = g++
 

--- a/perf.cpp
+++ b/perf.cpp
@@ -1,0 +1,52 @@
+#include "perf.h"
+
+#include <SDL2/SDL.h>
+
+#include <iomanip>
+#include <iostream>
+#include <utility>
+
+constexpr float kMsPerSecond = 1000.0;
+
+void Perf::StartTimer(std::string phase_name) {
+  if (enabled_) {
+    phase_start_timers_[phase_name] = SDL_GetTicks();
+  }
+}
+
+void Perf::StopTimer(std::string phase_name) {
+  if (enabled_) {
+    if (phase_start_timers_.find(phase_name) == phase_start_timers_.end()) {
+      std::cout << "Unable to stop nonexistant timer " << phase_name
+                << std::endl;
+      return;
+    }
+    int current_time_ms = SDL_GetTicks();
+    int elapsed_time_ms = current_time_ms - phase_start_timers_[phase_name];
+    bool new_timer = phase_accumulated_time_.find(phase_name) ==
+                     phase_accumulated_time_.end();
+    int current_accumulated_time_ms =
+        new_timer ? 0 : phase_accumulated_time_[phase_name];
+    phase_accumulated_time_[phase_name] =
+        current_accumulated_time_ms + elapsed_time_ms;
+  }
+}
+
+void Perf::ReportResults() {
+  total_frames_++;
+  if (enabled_ && (total_frames_ % print_freq_in_frames_ == 0)) {
+    std::cout << "Performance Report After " << print_freq_in_frames_
+              << " Frames" << std::endl;
+    for (const auto& [name, time] : phase_accumulated_time_) {
+      float timer_average = static_cast<float>(time) / print_freq_in_frames_;
+      std::cout << std::setw(15) << name << ": " << timer_average << "ms"
+                << std::endl;
+    }
+    // Put a space between reports.
+    std::cout << std::endl;
+
+    // Clear the internal maps
+    phase_start_timers_.clear();
+    phase_accumulated_time_.clear();
+  }
+}

--- a/perf.h
+++ b/perf.h
@@ -1,0 +1,47 @@
+#ifndef PERF_H
+#define PERF_H
+
+#include <unordered_map>
+#include <string>
+
+// Perf is a class designed to keep track of performance when performance
+// profiling is desired. It can be enabled or disabled.
+//
+// Usage:
+//   For each phase of execution, call StartTimer with a name.
+//   When that phase completes, call StopTimer with the same name.
+//   The total time is accumulated for the desired number of frames,
+//   specified in the ctor with the print_freq_in_frames variable.
+//   Each timer should only be updated once per frame.
+//   Start must be called before Stop for a given timer name.
+class Perf {
+ public:
+  Perf(bool enabled, int print_freq_in_frames)
+      : enabled_(enabled),
+        print_freq_in_frames_(print_freq_in_frames),
+        total_frames_(0) {}
+  virtual ~Perf() = default;
+
+  // Start the timer with the given name.
+  void StartTimer(std::string phase_name);
+
+  // Stop the timer with the given name and accumulate the duration in the
+  // total.
+  void StopTimer(std::string phase_name);
+
+  // Reports the timing results and clears the internal maps
+  // if the number of displayed frames is equal to the desired
+  // value specified by print_freq_in_frames.
+  void ReportResults();
+
+ private:
+  bool enabled_;
+  size_t print_freq_in_frames_;
+  // Track the number of times ReportResults is called (once per frame).
+  int total_frames_;
+
+  std::unordered_map<std::string, int> phase_start_timers_;
+  std::unordered_map<std::string, int> phase_accumulated_time_;
+};
+
+#endif /* PERF_H */

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -7,21 +7,25 @@
 
 constexpr char kAssetPath[] = "assets/";
 
-Sprite::Sprite(std::string sprite_sheet_name, SDL_Rect location)
+Sprite::Sprite(std::string sprite_sheet_name, SDL_Rect location,
+               SDL_Renderer* renderer)
     : sprite_sheet_name_(sprite_sheet_name), source_location_(location) {
-  // Check if we've already opened this sprite sheet.
-  if (Sprite::sprite_sheets_.find(sprite_sheet_name) != sprite_sheets_.end()) {
-    std::stringstream file_path;
-    file_path << kAssetPath << sprite_sheet_name << ".png";
-    // If the file has never been opened, open it an cache the result.
-    SDL_Surface* surface = IMG_Load(file_path.str().c_str());
-    if (!surface) {
-      std::cout << "Couldn't load image " << sprite_sheet_name
-                << ". Error: " << IMG_GetError();
+      // Check if we've already opened this sprite sheet.
+      if (Sprite::sprite_textures_.find(sprite_sheet_name) ==
+          sprite_textures_.end()) {
+        std::stringstream file_path;
+        file_path << kAssetPath << sprite_sheet_name << ".png";
+        // If the file has never been opened, open it an cache the result.
+        SDL_Surface* surface = IMG_Load(file_path.str().c_str());
+        if (!surface) {
+          std::cout << "Couldn't load image " << sprite_sheet_name
+                    << ". Error: " << IMG_GetError();
+        }
+        // Convert the sprite sheet SDL_Surface to a SDL_Texture for caching.
+        SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
+        sprite_textures_[sprite_sheet_name] = texture;
+      }
     }
-    sprite_sheets_[sprite_sheet_name] = surface;
-  }
-}
 
-std::unordered_map<std::string, SDL_Surface*> Sprite::sprite_sheets_ =
-    std::unordered_map<std::string, SDL_Surface*>();
+    std::unordered_map<std::string, SDL_Texture*> Sprite::sprite_textures_ =
+        std::unordered_map<std::string, SDL_Texture*>();

--- a/sprite.h
+++ b/sprite.h
@@ -2,26 +2,35 @@
 #define SPRITE_H
 
 #include <SDL2/SDL.h>
+
 #include <string>
 #include <unordered_map>
 
 class Sprite {
  public:
   // Ctor takes the sprite sheet file name that this sprite comes from.
-  // Additionally, it takes a SpriteLocation indicating the location on the
+  // Additionally, it takes a Sprite Location indicating the location on the
   // sheet that the sprite should be pulled from.
-  Sprite(std::string sprite_sheet_name_, SDL_Rect location);
+  // It also takes a pointer to the renderer in order to make textures.
+  // The renderer is not owned by the sprite.
+  Sprite(std::string sprite_sheet_name_, SDL_Rect location,
+        SDL_Renderer* renderer);
   virtual ~Sprite() = default;
 
-  virtual SDL_Surface* GetSpriteSheet() const {
-    return sprite_sheets_[sprite_sheet_name_];
+  virtual SDL_Texture* GetSpriteTexture() const {
+    return sprite_textures_[sprite_sheet_name_];
   }
 
   virtual SDL_Rect GetSourceLocation() const { return source_location_; }
 
+  // Cache the texture once the Graphics class makes it for us.
+  virtual void CacheTexture(SDL_Texture* texture) {
+    sprite_textures_[sprite_sheet_name_] = texture;
+  }
+
  private:
   // Sprite sheets. Key is the sheet file name minus extension.
-  static std::unordered_map<std::string, SDL_Surface*> sprite_sheets_;
+  static std::unordered_map<std::string, SDL_Texture*> sprite_textures_;
 
   // Keep track of the sprite sheet this sprite is from.
   const std::string sprite_sheet_name_;


### PR DESCRIPTION
Frame rate was maxing out at 20-40FPS. Some performance profiling
revealed that there were 2 places taking up all the time:

1. Opening the sprite sheet file.
2. Converting SDL_Surface to SDL_Texture.

Problem #1 is fixed by fixing a bug in the Sprite ctor - the sprite
sheet file should only be opened once. Inverted logic was making it
reopen every time.

Problem #2 was fixed by caching the SDL_Texture instead of the
SDL_Surface in the static map in the Sprite class.

FPS on my machine was well over 1000 now. Capping FPS at 50 is the next
task.