### PR TITLE
Converted the Perf object to a singleton.

### DIFF
--- a/animated_sprite.h
+++ b/animated_sprite.h
@@ -9,7 +9,6 @@
 
 #include "animation.h"
 #include "location.h"
-#include "perf.h"
 #include "sprite.h"
 
 using AnimationMap = std::unordered_map<AnimationType, Animation>;

--- a/game.cpp
+++ b/game.cpp
@@ -29,20 +29,17 @@ bool Game::Run() {
   // Event struct to grab input events from SDL.
   SDL_Event event;
 
-  // Create a perf object.
-  Perf perf(true, constants::kFramesPerFpsCheck);
-
   SDL_Rect background_source = {.x = 132, .y = 0, .w = 500, .h = 298};
 
   // Create background.
   Sprite background("Namek Background", background_source, kBackgroundScale,
                     graphics_.GetRenderer());
 
-  perf.StartTimer("create_sprite");
+  Perf::GetPerf()->StartTimer("create_sprite");
 
   AnimatedSprite goku("goku_sprite_sheet(in_progress)", graphics_.GetRenderer(),
                       kGokuScale, GetGokuAnimations());
-  perf.StopTimer("create_sprite");
+  Perf::GetPerf()->StopTimer("create_sprite");
 
   Location goku_location(50, 500);
 
@@ -54,9 +51,9 @@ bool Game::Run() {
     frame_start_time_ms = SDL_GetTicks();
 
     // Add the background
-    graphics_.AddSprite(background, Location(0, 0), &perf);
-    perf.StartTimer("game_loop");
-    perf.StartTimer("input");
+    graphics_.AddSprite(background, Location(0, 0));
+    Perf::GetPerf()->StartTimer("game_loop");
+    Perf::GetPerf()->StartTimer("input");
 
     // Clear out old keyup/keydown events.
     input_.BeginNewFrame();
@@ -129,16 +126,16 @@ bool Game::Run() {
       super_saiyan = false;
     }
 
-    perf.StopTimer("input");
+    Perf::GetPerf()->StopTimer("input");
 
-    graphics_.AddSprite(goku, goku_location, &perf);
-    perf.StartTimer("draw");
+    graphics_.AddSprite(goku, goku_location);
+    Perf::GetPerf()->StartTimer("draw");
     graphics_.DrawNextFrame();
-    perf.StopTimer("draw");
+    Perf::GetPerf()->StopTimer("draw");
 
     LimitFrameRate();
-    perf.StopTimer("game_loop");
-    perf.ReportResults();
+    Perf::GetPerf()->StopTimer("game_loop");
+    Perf::GetPerf()->ReportResults();
   }
 }
 

--- a/graphics.cpp
+++ b/graphics.cpp
@@ -4,6 +4,7 @@
 
 #include "constants.h"
 #include "location.h"
+#include "perf.h"
 
 // Graphics-related constants.
 constexpr char kGameTitle[] = "DBZ";
@@ -39,23 +40,22 @@ void Graphics::DrawNextFrame() {
   SDL_RenderClear(renderer_);
 }
 
-void Graphics::AddSprite(const Sprite& sprite, const SDL_Rect& destination,
-                         Perf* perf) {
+void Graphics::AddSprite(const Sprite& sprite, const SDL_Rect& destination) {
   // Draw this sprite on the screen.
   SDL_Rect source = sprite.GetSourceLocation();
-  perf->StartTimer("render_copy");
+  Perf::GetPerf()->StartTimer("render_copy");
   SDL_RenderCopy(renderer_, sprite.GetSpriteTexture(), &source, &destination);
-  perf->StopTimer("render_copy");
+  Perf::GetPerf()->StopTimer("render_copy");
 }
 
-void Graphics::AddSprite(const Sprite& sprite, Location location, Perf* perf) {
+void Graphics::AddSprite(const Sprite& sprite, Location location) {
   SDL_Rect source = sprite.GetSourceLocation();
   SDL_Rect destination = {.x = location.x,
                           .y = location.y,
                           .w = static_cast<int>(source.w * sprite.GetScale()),
                           .h = static_cast<int>(source.h * sprite.GetScale())};
   // Draw this sprite on the screen.
-  perf->StartTimer("render_copy");
+  Perf::GetPerf()->StartTimer("render_copy");
   SDL_RenderCopy(renderer_, sprite.GetSpriteTexture(), &source, &destination);
-  perf->StopTimer("render_copy");
+  Perf::GetPerf()->StopTimer("render_copy");
 }

--- a/graphics.h
+++ b/graphics.h
@@ -4,7 +4,6 @@
 
 #include "animated_sprite.h"
 #include "location.h"
-#include "perf.h"
 #include "sprite.h"
 
 class Graphics {
@@ -20,11 +19,11 @@ class Graphics {
 
   // Add this sprite to the renderer for the next frame, scaled to fit the
   // provided destination rectangle.
-  void AddSprite(const Sprite& sprite, const SDL_Rect& destination, Perf* perf);
+  void AddSprite(const Sprite& sprite, const SDL_Rect& destination);
 
   // Add a sprite to the renderer at the specified location, scaled by the
   // sprite scale value.
-  void AddSprite(const Sprite& sprite, Location location, Perf* perf);
+  void AddSprite(const Sprite& sprite, Location location);
 
   // This returns a pointer to the renderer struct.
   // Exposing this is unfortunate but the Sprite needs access to it to create

--- a/perf.cpp
+++ b/perf.cpp
@@ -1,5 +1,4 @@
 #include "perf.h"
-#include "constants.h"
 
 #include <SDL2/SDL.h>
 
@@ -7,7 +6,21 @@
 #include <iostream>
 #include <utility>
 
+#include "constants.h"
+
 constexpr float kMsPerSecond = 1000.0;
+
+// Static members must be initialized out-of-line.
+std::unique_ptr<Perf> Perf::instance_ = nullptr;
+
+Perf* Perf::GetPerf() {
+  if (!instance_) {
+    // Calling `new` to access private ctor.
+    instance_ =
+        std::unique_ptr<Perf>(new Perf(true, constants::kFramesPerFpsCheck));
+  }
+  return instance_.get();
+}
 
 void Perf::StartTimer(std::string phase_name) {
   if (enabled_) {

--- a/perf.h
+++ b/perf.h
@@ -1,11 +1,14 @@
 #ifndef PERF_H
 #define PERF_H
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 
 // Perf is a class designed to keep track of performance when performance
 // profiling is desired. It can be enabled or disabled.
+//
+// It is a singleton that is not thread-safe.
 //
 // Usage:
 //   For each phase of execution, call StartTimer with a name.
@@ -16,11 +19,9 @@
 //   Start must be called before Stop for a given timer name.
 class Perf {
  public:
-  Perf(bool enabled, int print_freq_in_frames)
-      : enabled_(enabled),
-        print_freq_in_frames_(print_freq_in_frames),
-        total_frames_(0) {}
   virtual ~Perf() = default;
+
+  static Perf* GetPerf();
 
   // Start the timer with the given name.
   void StartTimer(std::string phase_name);
@@ -35,7 +36,16 @@ class Perf {
   void ReportResults();
 
  private:
-  // Computes and returns the FPS..
+  // Ctor is private - this is a singleton.
+  Perf(bool enabled, int print_freq_in_frames)
+      : enabled_(enabled),
+        print_freq_in_frames_(print_freq_in_frames),
+        total_frames_(0) {}
+
+  // The only perf object instance.
+  static std::unique_ptr<Perf> instance_;
+
+  // Computes and returns the FPS.
   float CalculateFps();
 
   int last_fps_check_time_ms_;


### PR DESCRIPTION
The perf object is now a static singleton that can be accessed with the
static method Perf::GetPerf() from anywhere. It is not thread-safe: if
we start using multiple threads this will need to be mutex-guarded.